### PR TITLE
Add native JWT support with documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,71 @@ console.log(validatedData ? 'Valid Token:' : 'Invalid Token');
 
 ---
 
+## JWT (native, dependency-free)
+
+`hash-token` ships with a zero-dependency JSON Web Token implementation that relies on Node.js `crypto` only. It protects against common JWT pitfalls, enforces strict validation and integrates with the existing `AdvancedTokenManager` class.
+
+### Core helpers
+
+| Helper | Description |
+| --- | --- |
+| `signJwt(payload, options)` | Builds a signed JWT string using HMAC (HS256 or HS512). |
+| `verifyJwt(token, options)` | Validates structure, signature and claims before returning the payload. |
+
+### Signing options
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Required. HMAC secret used to sign the token. |
+| `algorithm` | `'HS256' \| 'HS512'` | `HS256` | Chooses the HMAC digest. |
+| `expiresIn` | `number` (seconds) | — | Adds an `exp` claim relative to the current time. |
+| `notBefore` | `number` (seconds) | — | Adds an `nbf` claim relative to the current time. |
+| `issuedAt` | `number` (epoch seconds) | now | Overrides the automatic `iat`. |
+| `issuer` | `string` | — | Ensures a consistent `iss` claim. |
+| `audience` | `string \| string[]` | — | Accepts a single or multiple audiences. |
+| `subject` | `string` | — | Sets the `sub` claim. |
+
+### Verification options
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Required. Must match the signing secret. |
+| `algorithms` | `JwtAlgorithm[]` | any supported | Restricts which algorithms are allowed. |
+| `clockTolerance` | `number` (seconds) | `0` | Accepts small clock skews for `exp`, `nbf`, `iat`. |
+| `maxAge` | `number` (seconds) | — | Caps the lifetime counted from `iat`. |
+| `issuer` | `string \| string[]` | — | Expected issuers. Missing or mismatched claims reject the token. |
+| `audience` | `string \| string[]` | — | Expected audiences. |
+| `subject` | `string` | — | Expected subject. |
+
+### Usage examples
+
+```typescript
+import { signJwt, verifyJwt } from 'hash-token';
+
+const secret = 'rotate-me';
+
+const token = signJwt(
+    { userId: 'u-123', role: 'admin' },
+    { secret, algorithm: 'HS512', expiresIn: 300 }
+);
+
+const payload = verifyJwt(token, {
+    secret,
+    algorithms: ['HS512'],
+    audience: 'dashboard'
+});
+
+console.log(payload);
+```
+
+For end-to-end samples, check the new scripts under [`examples/`](./examples):
+
+- [`sign-verify.ts`](./examples/sign-verify.ts)
+- [`with-claims.ts`](./examples/with-claims.ts)
+- [`manager-integration.ts`](./examples/manager-integration.ts)
+
+---
+
 ## Tests
 
 Use Jest to test functionality under various scenarios, such as altered tokens or invalid salts.

--- a/README_fr.md
+++ b/README_fr.md
@@ -108,6 +108,71 @@ console.log(validatedData ? 'Token Valide :' : 'Token Invalide');
 
 ---
 
+## JWT (natif, sans dépendances)
+
+`hash-token` intègre désormais une implémentation JSON Web Token sans dépendances externes, reposant uniquement sur `crypto` de Node.js. Elle renforce les contrôles de sécurité, interdit `alg: none` et s'utilise avec ou sans `AdvancedTokenManager`.
+
+### Utilitaires principaux
+
+| Helper | Description |
+| --- | --- |
+| `signJwt(payload, options)` | Crée un JWT signé avec HMAC (HS256 ou HS512). |
+| `verifyJwt(token, options)` | Vérifie structure, signature et claims avant de retourner le payload. |
+
+### Options de signature
+
+| Option | Type | Valeur par défaut | Remarques |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Obligatoire. Secret HMAC utilisé pour signer. |
+| `algorithm` | `'HS256' \| 'HS512'` | `HS256` | Choix de l'algorithme HMAC. |
+| `expiresIn` | `number` (secondes) | — | Ajoute `exp` relatif à l'horodatage actuel. |
+| `notBefore` | `number` (secondes) | — | Ajoute `nbf` relatif à maintenant. |
+| `issuedAt` | `number` (secondes) | maintenant | Remplace le `iat` automatique. |
+| `issuer` | `string` | — | Définit le claim `iss`. |
+| `audience` | `string \| string[]` | — | Public(s) ciblé(s). |
+| `subject` | `string` | — | Définit `sub`. |
+
+### Options de vérification
+
+| Option | Type | Valeur par défaut | Remarques |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Obligatoire. Doit correspondre au secret de signature. |
+| `algorithms` | `JwtAlgorithm[]` | tous | Restreint les algorithmes acceptés. |
+| `clockTolerance` | `number` (secondes) | `0` | Tolérance pour `exp`, `nbf`, `iat`. |
+| `maxAge` | `number` (secondes) | — | Durée maximale depuis `iat`. |
+| `issuer` | `string \| string[]` | — | Émetteurs attendus. |
+| `audience` | `string \| string[]` | — | Public attendu. |
+| `subject` | `string` | — | Sujet attendu. |
+
+### Exemple rapide
+
+```typescript
+import { signJwt, verifyJwt } from 'hash-token';
+
+const secret = 'remplacez-moi';
+
+const token = signJwt(
+    { utilisateurId: 'u-123', rôle: 'admin' },
+    { secret, algorithm: 'HS512', expiresIn: 300 }
+);
+
+const payload = verifyJwt(token, {
+    secret,
+    algorithms: ['HS512'],
+    audience: 'dashboard'
+});
+
+console.log(payload);
+```
+
+Consultez également les nouveaux exemples complets dans [`examples/`](./examples) :
+
+- [`sign-verify.ts`](./examples/sign-verify.ts)
+- [`with-claims.ts`](./examples/with-claims.ts)
+- [`manager-integration.ts`](./examples/manager-integration.ts)
+
+---
+
 ## Tests
 
 Utilisez Jest pour tester la fonctionnalité dans divers scénarios, tels que des tokens altérés ou des sels invalides.

--- a/README_pt.md
+++ b/README_pt.md
@@ -108,6 +108,71 @@ console.log(validatedData ? 'Token Válido:' : 'Token Inválido');
 
 ---
 
+## JWT (nativo, sem dependências)
+
+`hash-token` agora inclui uma implementação de JSON Web Token baseada apenas no `crypto` do Node.js, sem bibliotecas extras. Ela reforça as validações de segurança, bloqueia algoritmos inseguros e funciona lado a lado com a classe `AdvancedTokenManager`.
+
+### Utilitários principais
+
+| Helper | Descrição |
+| --- | --- |
+| `signJwt(payload, options)` | Gera um JWT assinado com HMAC (HS256 ou HS512). |
+| `verifyJwt(token, options)` | Valida estrutura, assinatura e claims antes de retornar o payload. |
+
+### Opções de assinatura
+
+| Opção | Tipo | Padrão | Observações |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Obrigatório. Segredo HMAC usado para assinar. |
+| `algorithm` | `'HS256' \| 'HS512'` | `HS256` | Define o digest HMAC. |
+| `expiresIn` | `number` (segundos) | — | Adiciona o claim `exp` relativo ao tempo atual. |
+| `notBefore` | `number` (segundos) | — | Adiciona o claim `nbf` relativo ao tempo atual. |
+| `issuedAt` | `number` (segundos) | agora | Substitui o `iat` automático. |
+| `issuer` | `string` | — | Garante consistência do claim `iss`. |
+| `audience` | `string \| string[]` | — | Aceita um ou vários públicos. |
+| `subject` | `string` | — | Define o claim `sub`. |
+
+### Opções de verificação
+
+| Opção | Tipo | Padrão | Observações |
+| --- | --- | --- | --- |
+| `secret` | `string` | — | Obrigatório. Deve corresponder ao segredo usado na assinatura. |
+| `algorithms` | `JwtAlgorithm[]` | todos suportados | Restringe os algoritmos aceitos. |
+| `clockTolerance` | `number` (segundos) | `0` | Tolera pequenos desvios de relógio em `exp`, `nbf`, `iat`. |
+| `maxAge` | `number` (segundos) | — | Limita a vida útil contando a partir de `iat`. |
+| `issuer` | `string \| string[]` | — | Lista de emissores esperados. Falha se ausente ou divergente. |
+| `audience` | `string \| string[]` | — | Público esperado. |
+| `subject` | `string` | — | Sujeito esperado. |
+
+### Exemplo rápido
+
+```typescript
+import { signJwt, verifyJwt } from 'hash-token';
+
+const secret = 'troque-este-valor';
+
+const token = signJwt(
+    { usuarioId: 'u-123', perfil: 'admin' },
+    { secret, algorithm: 'HS512', expiresIn: 300 }
+);
+
+const payload = verifyJwt(token, {
+    secret,
+    algorithms: ['HS512'],
+    audience: 'dashboard'
+});
+
+console.log(payload);
+```
+
+Consulte também os novos exemplos completos em [`examples/`](./examples):
+
+- [`sign-verify.ts`](./examples/sign-verify.ts)
+- [`with-claims.ts`](./examples/with-claims.ts)
+- [`manager-integration.ts`](./examples/manager-integration.ts)
+
+---
+
 ## Testes
 
 Use o Jest para testar a funcionalidade em vários cenários, como tokens adulterados ou salts inválidos.

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,0 +1,8 @@
+# Security Notes — JWT integration
+
+- **Strong algorithms only:** the native helper only allows HS256 and HS512. Tokens declaring `alg: none` or unsupported algorithms are rejected before signature checks.
+- **Verified structure:** base64url segments are validated, decoded and re-encoded to detect truncation or tampering before signature comparison.
+- **Timing-safe signature checks:** comparisons use `crypto.timingSafeEqual` to avoid leaking signature length or early exits.
+- **Claim enforcement:** `exp`, `nbf`, `iat`, `iss`, `aud`, and `sub` are validated for type, presence (when expected) and logical correctness. Optional `clockTolerance` and `maxAge` defend against clock drift and replay attacks.
+- **Secret management:** `AdvancedTokenManager` forwards its managed secret to JWT helpers, keeping configuration centralized while allowing overrides when explicitly requested.
+- **Input validation:** signing rejects non-object payloads and conflicting claims; verification fails fast on malformed headers, payloads or options with invalid types.

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from '@jest/globals';
+import * as crypto from 'crypto';
+import AdvancedTokenManager from '../src/AdvancedTokenManager';
+import { signJwt, verifyJwt, JwtAlgorithm } from '../src/jwt';
+
+const SECRET = 'super-secret-test-secret-1234567890';
+
+function toBase64Url(data: string | Buffer): string {
+    const buffer = typeof data === 'string' ? Buffer.from(data, 'utf8') : Buffer.from(data);
+    return buffer.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function decodeBase64Url(segment: string): Buffer {
+    const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const pad = (4 - (normalized.length % 4)) % 4;
+    return Buffer.from(normalized + '='.repeat(pad), 'base64');
+}
+
+function createHmacToken(
+    header: Record<string, unknown>,
+    payload: unknown,
+    secret: string = SECRET,
+    algorithm: JwtAlgorithm = 'HS256'
+): string {
+    const headerSegment = toBase64Url(JSON.stringify(header));
+    const payloadContent = typeof payload === 'string' || Buffer.isBuffer(payload)
+        ? payload
+        : JSON.stringify(payload);
+    const payloadSegment = toBase64Url(payloadContent);
+    const digestAlgorithm = algorithm === 'HS512' ? 'sha512' : 'sha256';
+    const signature = toBase64Url(
+        crypto.createHmac(digestAlgorithm, secret).update(`${headerSegment}.${payloadSegment}`).digest()
+    );
+    return `${headerSegment}.${payloadSegment}.${signature}`;
+}
+
+function makeJwt(payload: Record<string, unknown>, algorithm: JwtAlgorithm = 'HS256') {
+    return signJwt(payload, { secret: SECRET, algorithm });
+}
+
+describe('JWT signing and verification', () => {
+    test('signs and verifies payload using HS256', () => {
+        const token = makeJwt({ user: 'alice' });
+        const verified = verifyJwt<{ user: string; iat: number }>(token, { secret: SECRET });
+
+        expect(verified.user).toBe('alice');
+        expect(typeof verified.iat).toBe('number');
+    });
+
+    test('signs and verifies payload using HS512', () => {
+        const token = makeJwt({ scope: 'admin' }, 'HS512');
+        const verified = verifyJwt<{ scope: string }>(token, { secret: SECRET, algorithms: ['HS512'] });
+
+        expect(verified.scope).toBe('admin');
+    });
+
+    test('rejects tokens signed with an unexpected algorithm', () => {
+        const token = makeJwt({ flag: true }, 'HS256');
+        expect(() => verifyJwt(token, { secret: SECRET, algorithms: ['HS512'] })).toThrow('Algorithm HS256 is not allowed.');
+    });
+
+    test('rejects tampered payloads', () => {
+        const token = makeJwt({ id: 42 });
+        const parts = token.split('.');
+        const tamperedPayload = toBase64Url(JSON.stringify({ id: 43 }));
+        const forgedToken = `${parts[0]}.${tamperedPayload}.${parts[2]}`;
+
+        expect(() => verifyJwt(forgedToken, { secret: SECRET })).toThrow('Invalid JWT signature.');
+    });
+
+    test('rejects tokens with modified headers', () => {
+        const token = makeJwt({ id: 123 });
+        const parts = token.split('.');
+        const header = JSON.parse(decodeBase64Url(parts[0]).toString('utf8'));
+        header.alg = 'HS512';
+        const forgedHeader = toBase64Url(JSON.stringify(header));
+        const forgedToken = `${forgedHeader}.${parts[1]}.${parts[2]}`;
+
+        expect(() => verifyJwt(forgedToken, { secret: SECRET })).toThrow('Invalid JWT signature.');
+    });
+
+    test('rejects alg none tokens', () => {
+        const header = toBase64Url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+        const payload = toBase64Url(JSON.stringify({ user: 'mallory' }));
+        const fakeSignature = toBase64Url('ignored');
+        const token = `${header}.${payload}.${fakeSignature}`;
+
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Unsigned JWTs (alg "none") are not allowed.');
+    });
+
+    test('rejects invalid token structure', () => {
+        expect(() => verifyJwt('invalid-token', { secret: SECRET })).toThrow('Invalid token structure.');
+    });
+
+    test('rejects invalid base64 segments', () => {
+        const token = '@@@.def.ghi';
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid base64url encoding in header.');
+    });
+
+    test('rejects malformed base64 segments', () => {
+        const token = 'ab.def.ghi';
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Malformed base64url segment in header.');
+    });
+
+    test('expires tokens past exp claim', () => {
+        const issuedAt = 1_000_000;
+        const token = signJwt({ data: 'expiring' }, { secret: SECRET, issuedAt, expiresIn: 30, clockTimestamp: issuedAt });
+
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: issuedAt + 31 })).toThrow('JWT expired.');
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: issuedAt + 30 })).not.toThrow();
+    });
+
+    test('enforces not-before (nbf) with optional tolerance', () => {
+        const token = signJwt({ feature: true }, { secret: SECRET, notBefore: 60, issuedAt: 0, clockTimestamp: 0 });
+
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: 10 })).toThrow('JWT not active yet.');
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: 10, clockTolerance: 60 })).not.toThrow();
+    });
+
+    test('validates issuer, audience, and subject claims', () => {
+        const token = signJwt(
+            { data: 'claims' },
+            {
+                secret: SECRET,
+                issuer: 'issuer.example',
+                audience: ['app-one', 'app-two'],
+                subject: 'user-123'
+            }
+        );
+
+        const payload = verifyJwt(token, {
+            secret: SECRET,
+            issuer: ['issuer.example'],
+            audience: 'app-two',
+            subject: 'user-123'
+        });
+
+        expect(payload.sub).toBe('user-123');
+        expect(payload.iss).toBe('issuer.example');
+    });
+
+    test('rejects mismatching audiences', () => {
+        const token = signJwt({ data: 'aud' }, { secret: SECRET, audience: 'service-a' });
+        expect(() => verifyJwt(token, { secret: SECRET, audience: 'service-b' })).toThrow('JWT audience mismatch.');
+    });
+
+    test('rejects tokens missing required claims when expected', () => {
+        const token = signJwt({ data: 'no-claims' }, { secret: SECRET });
+        expect(() => verifyJwt(token, { secret: SECRET, audience: 'app' })).toThrow('JWT missing required audience claim.');
+        expect(() => verifyJwt(token, { secret: SECRET, issuer: 'issuer' })).toThrow('JWT missing required issuer claim.');
+        expect(() => verifyJwt(token, { secret: SECRET, subject: 'subject' })).toThrow('JWT missing required subject claim.');
+    });
+
+    test('rejects tokens issued in the future', () => {
+        const token = signJwt({ data: 'future' }, { secret: SECRET, issuedAt: 1_000 });
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: 500 })).toThrow('JWT used before issued.');
+    });
+
+    test('enforces maxAge constraints', () => {
+        const issuedAt = 10_000;
+        const token = signJwt({ data: 'age' }, { secret: SECRET, issuedAt });
+
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: issuedAt + 100, maxAge: 90 })).toThrow('JWT exceeds maxAge.');
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: issuedAt + 80, maxAge: 90 })).not.toThrow();
+    });
+
+    test('rejects invalid claim types', () => {
+        const header = toBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+        const payload = toBase64Url(JSON.stringify({ exp: 'soon' }));
+        const signingInput = `${header}.${payload}`;
+        const signature = toBase64Url(crypto.createHmac('sha256', SECRET).update(signingInput).digest());
+        const token = `${signingInput}.${signature}`;
+
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Claim "exp" must be a finite number.');
+    });
+
+    test('rejects verification with wrong secret', () => {
+        const token = makeJwt({ session: 'abc' });
+        expect(() => verifyJwt(token, { secret: 'wrong-secret' })).toThrow('Invalid JWT signature.');
+    });
+
+    test('integrates with AdvancedTokenManager', () => {
+        const manager = new AdvancedTokenManager(SECRET, ['salt-a', 'salt-b']);
+        const token = manager.generateJwt({ action: 'login' }, { algorithm: 'HS512' });
+        const payload = manager.validateJwt<{ action: string; iat: number }>(token, { algorithms: ['HS512'] });
+
+        expect(payload.action).toBe('login');
+        expect(payload.iat).toBeDefined();
+    });
+
+    test('signJwt enforces payload format and options', () => {
+        expect(() => signJwt('not-an-object' as unknown as Record<string, unknown>, { secret: SECRET })).toThrow('Payload must be a plain object.');
+        expect(() => signJwt({}, { secret: SECRET, expiresIn: -10 })).toThrow('expiresIn must be a positive number of seconds.');
+        expect(() => signJwt({}, { secret: SECRET, notBefore: Number.NaN })).toThrow('notBefore must be a number of seconds.');
+        expect(() => signJwt({ iss: 'one' }, { secret: SECRET, issuer: 'two' })).toThrow('Claim "iss" already present with a different value.');
+        expect(() => signJwt({}, { secret: SECRET, algorithm: 'HS256', header: { alg: 'HS512' } })).toThrow('Header algorithm mismatch.');
+        expect(() => signJwt({}, { secret: '' })).toThrow('A non-empty secret is required to sign a JWT.');
+        expect(() => signJwt({}, { secret: SECRET, algorithm: 'HS1024' as JwtAlgorithm })).toThrow('Unsupported signing algorithm: HS1024.');
+        expect(() => signJwt({}, { secret: SECRET, header: { typ: 'JWS' } })).toThrow('Header type must be "JWT".');
+        expect(() => signJwt({}, { secret: SECRET, clockTimestamp: Number.POSITIVE_INFINITY })).toThrow('clockTimestamp must be a finite number.');
+        expect(() => signJwt({}, { secret: SECRET, audience: '' })).toThrow('Audience must be a non-empty string.');
+        expect(() => signJwt({}, { secret: SECRET, audience: ['team', ''] as unknown as string[] })).toThrow('Audience must be a non-empty string.');
+        expect(() => signJwt({ iat: 'now' } as unknown as Record<string, unknown>, { secret: SECRET })).toThrow('Claim "iat" must be a finite number.');
+        expect(() => signJwt({ exp: 'soon' } as unknown as Record<string, unknown>, { secret: SECRET })).toThrow('Claim "exp" must be a finite number.');
+        expect(() => signJwt({ nbf: 'later' } as unknown as Record<string, unknown>, { secret: SECRET })).toThrow('Claim "nbf" must be a finite number.');
+        expect(() => signJwt({ sub: '' } as unknown as Record<string, unknown>, { secret: SECRET })).toThrow('Claim "sub" must be a non-empty string.');
+    });
+
+    test('signJwt supports pre-existing standard claims', () => {
+        expect(() => signJwt({ aud: ['service-a', 'service-b'] } as unknown as Record<string, unknown>, { secret: SECRET })).not.toThrow();
+        expect(() => signJwt({ aud: 'service-c' } as unknown as Record<string, unknown>, { secret: SECRET })).not.toThrow();
+        expect(() => signJwt({ iss: 'issuer-a' } as unknown as Record<string, unknown>, { secret: SECRET })).not.toThrow();
+        expect(() => signJwt({ sub: 'subject-a' } as unknown as Record<string, unknown>, { secret: SECRET })).not.toThrow();
+    });
+
+    test('verifyJwt validates option values', () => {
+        const token = makeJwt({ check: true });
+        expect(() => verifyJwt(token, { secret: SECRET, clockTolerance: -1 })).toThrow('clockTolerance must be a non-negative number.');
+        const withIssuer = signJwt({ data: 'issuer' }, { secret: SECRET, issuer: 'issuer' });
+        expect(() => verifyJwt(withIssuer, { secret: SECRET, issuer: [''] as unknown as string[] })).toThrow('Issuer values must be non-empty strings.');
+        expect(() => verifyJwt(withIssuer, { secret: SECRET, issuer: '' as unknown as string })).toThrow('Issuer must be a non-empty string.');
+        const withSubject = signJwt({ data: 'subject' }, { secret: SECRET, subject: 'subject' });
+        expect(() => verifyJwt(withSubject, { secret: SECRET, subject: '' })).toThrow('Subject must be a non-empty string.');
+        const withAudience = signJwt({ data: 'aud' }, { secret: SECRET, audience: 'valid' });
+        expect(() => verifyJwt(withAudience, { secret: SECRET, audience: [] as unknown as string[] })).toThrow('Audience array must not be empty.');
+        expect(() => verifyJwt(123 as unknown as string, { secret: SECRET })).toThrow('Token must be a non-empty string.');
+        expect(() => verifyJwt('token', { secret: '' })).toThrow('A non-empty secret is required to verify a JWT.');
+        expect(() => verifyJwt(token, { secret: SECRET, clockTimestamp: Number.NaN })).toThrow('clockTimestamp must be a finite number.');
+        expect(() => verifyJwt(token, { secret: SECRET, maxAge: 0 })).toThrow('maxAge must be a positive number of seconds.');
+    });
+
+    test('rejects headers that fail JSON parsing', () => {
+        const token = `${toBase64Url('invalid-json')}.${toBase64Url(JSON.stringify({ data: true }))}.${toBase64Url('sig')}`;
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid JWT header.');
+    });
+
+    test('rejects headers that are not JSON objects', () => {
+        const token = `${toBase64Url('[]')}.${toBase64Url(JSON.stringify({ data: true }))}.${toBase64Url('sig')}`;
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid JWT header.');
+    });
+
+    test('rejects headers without required algorithm', () => {
+        const token = createHmacToken({ typ: 'JWT' }, { data: true });
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Missing JWT algorithm.');
+    });
+
+    test('rejects tokens with unsupported algorithms', () => {
+        const token = createHmacToken({ typ: 'JWT', alg: 'RS256' }, { data: true });
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Unsupported algorithm: RS256.');
+    });
+
+    test('rejects tokens with invalid type header', () => {
+        const token = createHmacToken({ typ: 'JWS', alg: 'HS256' }, { data: true });
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid JWT type.');
+    });
+
+    test('rejects payloads that are not JSON objects', () => {
+        const token = createHmacToken({ alg: 'HS256', typ: 'JWT' }, JSON.stringify('hello'));
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid JWT payload.');
+    });
+
+    test('rejects invalid payload JSON', () => {
+        const token = createHmacToken({ alg: 'HS256', typ: 'JWT' }, '{');
+        expect(() => verifyJwt(token, { secret: SECRET })).toThrow('Invalid JWT payload.');
+    });
+
+    test('rejects maxAge when iat is missing', () => {
+        const token = createHmacToken({ alg: 'HS256', typ: 'JWT' }, { data: true });
+        expect(() => verifyJwt(token, { secret: SECRET, maxAge: 10 })).toThrow('Cannot apply maxAge without an "iat" claim.');
+    });
+
+    test('allows optional claims when not enforced', () => {
+        const token = signJwt({ aud: 'service', iss: 'issuer', sub: 'subject' }, { secret: SECRET });
+        expect(() => verifyJwt(token, { secret: SECRET })).not.toThrow();
+    });
+
+    test('rejects issuer mismatch', () => {
+        const token = signJwt({ iss: 'issuer-a' }, { secret: SECRET });
+        expect(() => verifyJwt(token, { secret: SECRET, issuer: 'issuer-b' })).toThrow('JWT issuer mismatch.');
+    });
+
+    test('rejects issuer mismatch from list', () => {
+        const token = signJwt({ iss: 'issuer-a' }, { secret: SECRET });
+        expect(() => verifyJwt(token, { secret: SECRET, issuer: ['issuer-b', 'issuer-c'] })).toThrow('JWT issuer mismatch.');
+    });
+
+    test('rejects subject mismatch', () => {
+        const token = signJwt({ sub: 'subject-a' }, { secret: SECRET });
+        expect(() => verifyJwt(token, { secret: SECRET, subject: 'subject-b' })).toThrow('JWT subject mismatch.');
+    });
+});

--- a/examples/manager-integration.ts
+++ b/examples/manager-integration.ts
@@ -1,0 +1,13 @@
+import AdvancedTokenManager from 'hash-token';
+
+const manager = new AdvancedTokenManager('manager-secret-change-me', ['salt-1', 'salt-2']);
+
+const jwt = manager.generateJwt(
+    { transaction: 'txn-123', amount: 99.99 },
+    { algorithm: 'HS512', expiresIn: 120 }
+);
+
+const verified = manager.validateJwt(jwt, { algorithms: ['HS512'] });
+
+console.log('Manager JWT:', jwt);
+console.log('Manager payload:', verified);

--- a/examples/manager-integration.ts
+++ b/examples/manager-integration.ts
@@ -1,4 +1,4 @@
-import AdvancedTokenManager from 'hash-token';
+import AdvancedTokenManager from '../src/index';
 
 const manager = new AdvancedTokenManager('manager-secret-change-me', ['salt-1', 'salt-2']);
 

--- a/examples/sign-verify.ts
+++ b/examples/sign-verify.ts
@@ -1,4 +1,4 @@
-import { signJwt, verifyJwt } from 'hash-token';
+import { signJwt, verifyJwt } from '../src/index';
 
 const secret = 'example-secret-change-me';
 

--- a/examples/sign-verify.ts
+++ b/examples/sign-verify.ts
@@ -1,0 +1,13 @@
+import { signJwt, verifyJwt } from 'hash-token';
+
+const secret = 'example-secret-change-me';
+
+const token = signJwt(
+    { id: 'user-42', role: 'reader' },
+    { secret, algorithm: 'HS256', expiresIn: 60 }
+);
+
+const payload = verifyJwt(token, { secret });
+
+console.log('Generated JWT:', token);
+console.log('Decoded payload:', payload);

--- a/examples/with-claims.ts
+++ b/examples/with-claims.ts
@@ -1,0 +1,26 @@
+import { signJwt, verifyJwt } from 'hash-token';
+
+const secret = 'claims-secret-change-me';
+
+const token = signJwt(
+    { featureFlag: 'beta-access' },
+    {
+        secret,
+        issuer: 'api.my-app.local',
+        subject: 'user-1001',
+        audience: ['dashboard', 'mobile-app'],
+        notBefore: 5,
+        expiresIn: 3600
+    }
+);
+
+const payload = verifyJwt(token, {
+    secret,
+    issuer: ['api.my-app.local'],
+    subject: 'user-1001',
+    audience: 'mobile-app',
+    clockTolerance: 5
+});
+
+console.log('JWT with claims:', token);
+console.log('Verified payload:', payload);

--- a/examples/with-claims.ts
+++ b/examples/with-claims.ts
@@ -1,4 +1,4 @@
-import { signJwt, verifyJwt } from 'hash-token';
+import { signJwt, verifyJwt } from '../src/index';
 
 const secret = 'claims-secret-change-me';
 

--- a/src/AdvancedTokenManager.ts
+++ b/src/AdvancedTokenManager.ts
@@ -1,4 +1,8 @@
 import * as crypto from 'crypto';
+import { signJwt, verifyJwt, SignJwtOptions, VerifyJwtOptions } from './jwt';
+
+type ManagerSignJwtOptions = Omit<SignJwtOptions, 'secret'> & { secret?: string };
+type ManagerVerifyJwtOptions = Omit<VerifyJwtOptions, 'secret'> & { secret?: string };
 
 //=======================================//
 // editable zone 
@@ -118,6 +122,21 @@ export default class AdvancedTokenManager {
 
     public extractData(token: string): string | null {
         return this.validateToken(token);
+    }
+
+    public generateJwt(payload: Record<string, unknown>, options?: ManagerSignJwtOptions): string {
+        const secret = options?.secret ?? this.secret;
+        const signOptions: SignJwtOptions = { ...(options || {}), secret };
+        return signJwt(payload, signOptions);
+    }
+
+    public validateJwt<T extends Record<string, unknown> = Record<string, unknown>>(
+        token: string,
+        options?: ManagerVerifyJwtOptions
+    ): T {
+        const secret = options?.secret ?? this.secret;
+        const verifyOptions: VerifyJwtOptions = { ...(options || {}), secret };
+        return verifyJwt<T>(token, verifyOptions);
     }
 
     public getConfig(): { secret: string; salts: string[] } {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import AdvancedTokenManager from './AdvancedTokenManager';
 
+export * from './jwt';
 export default AdvancedTokenManager;

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -1,0 +1,432 @@
+import * as crypto from 'crypto';
+
+export type JwtAlgorithm = 'HS256' | 'HS512';
+
+const HASH_ALGORITHMS: Record<JwtAlgorithm, string> = {
+    HS256: 'sha256',
+    HS512: 'sha512'
+};
+
+export interface JwtHeader {
+    alg: JwtAlgorithm;
+    typ: 'JWT';
+    [key: string]: unknown;
+}
+
+export interface SignJwtOptions {
+    secret: string;
+    algorithm?: JwtAlgorithm;
+    header?: Record<string, unknown>;
+    expiresIn?: number;
+    notBefore?: number;
+    audience?: string | string[];
+    issuer?: string;
+    subject?: string;
+    issuedAt?: number;
+    clockTimestamp?: number;
+}
+
+export interface VerifyJwtOptions {
+    secret: string;
+    algorithms?: JwtAlgorithm[];
+    clockTolerance?: number;
+    audience?: string | string[];
+    issuer?: string | string[];
+    subject?: string;
+    maxAge?: number;
+    clockTimestamp?: number;
+}
+
+interface JwtPayload extends Record<string, unknown> {
+    exp?: number;
+    nbf?: number;
+    iat?: number;
+    iss?: string;
+    aud?: string | string[];
+    sub?: string;
+}
+
+const BASE64URL_REGEXP = /^[A-Za-z0-9_-]*$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+    return buffer.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function normalizeBase64Url(input: string): string {
+    const padLength = (4 - (input.length % 4)) % 4;
+    return input.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat(padLength);
+}
+
+function base64UrlDecode(input: string, part: 'header' | 'payload' | 'signature'): Buffer {
+    if (!BASE64URL_REGEXP.test(input)) {
+        throw new Error(`Invalid base64url encoding in ${part}.`);
+    }
+    const normalized = normalizeBase64Url(input);
+    const buffer = Buffer.from(normalized, 'base64');
+    // Ensure that encoding/decoding round-trips to avoid silent truncation
+    if (base64UrlEncode(buffer) !== input.replace(/=+$/, '')) {
+        throw new Error(`Malformed base64url segment in ${part}.`);
+    }
+    return buffer;
+}
+
+function getTimestamp(optionsTimestamp?: number): number {
+    if (optionsTimestamp !== undefined) {
+        if (!Number.isFinite(optionsTimestamp)) {
+            throw new Error('clockTimestamp must be a finite number.');
+        }
+        return Math.floor(optionsTimestamp);
+    }
+    return Math.floor(Date.now() / 1000);
+}
+
+function normalizeAudience(audience: string | string[]): string[] {
+    if (Array.isArray(audience)) {
+        const entries = audience.map(value => {
+            if (typeof value !== 'string' || value.length === 0) {
+                throw new Error('Audience must be a non-empty string.');
+            }
+            return value;
+        });
+        if (entries.length === 0) {
+            throw new Error('Audience array must not be empty.');
+        }
+        return entries;
+    }
+    if (typeof audience !== 'string' || audience.length === 0) {
+        throw new Error('Audience must be a non-empty string.');
+    }
+    return [audience];
+}
+
+function assertClaimConsistency<T>(
+    claims: Record<string, unknown>,
+    key: keyof JwtPayload,
+    value: T | undefined
+): void {
+    if (value === undefined) {
+        return;
+    }
+    const existing = claims[key as string];
+    if (existing !== undefined && existing !== value) {
+        throw new Error(`Claim \"${String(key)}\" already present with a different value.`);
+    }
+    claims[key as string] = value as unknown;
+}
+
+function assertNumericClaim(claimName: keyof JwtPayload, value: unknown): asserts value is number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(`Claim \"${String(claimName)}\" must be a finite number.`);
+    }
+}
+
+function assertStringClaim(claimName: keyof JwtPayload, value: unknown): asserts value is string {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`Claim \"${String(claimName)}\" must be a non-empty string.`);
+    }
+}
+
+function createSignatureBuffer(algorithm: JwtAlgorithm, secret: string, signingInput: string): Buffer {
+    const hashAlgorithm = HASH_ALGORITHMS[algorithm];
+    return crypto.createHmac(hashAlgorithm, secret).update(signingInput).digest();
+}
+
+export function signJwt(
+    payload: Record<string, unknown>,
+    options: SignJwtOptions
+): string {
+    if (!isPlainObject(payload)) {
+        throw new Error('Payload must be a plain object.');
+    }
+    if (!options || typeof options.secret !== 'string' || options.secret.length === 0) {
+        throw new Error('A non-empty secret is required to sign a JWT.');
+    }
+    const algorithm: JwtAlgorithm = options.algorithm ?? 'HS256';
+    if (!HASH_ALGORITHMS[algorithm]) {
+        throw new Error(`Unsupported signing algorithm: ${String(algorithm)}.`);
+    }
+
+    const header: JwtHeader = {
+        typ: 'JWT',
+        alg: algorithm,
+        ...(options.header || {})
+    } as JwtHeader;
+
+    if (header.alg !== algorithm) {
+        throw new Error('Header algorithm mismatch.');
+    }
+    if (header.typ !== 'JWT') {
+        throw new Error('Header type must be "JWT".');
+    }
+
+    const timestamp = getTimestamp(options.clockTimestamp);
+    const claims: Record<string, unknown> = { ...payload };
+
+    if (options.issuedAt !== undefined) {
+        assertNumericClaim('iat', options.issuedAt);
+        assertClaimConsistency(claims, 'iat', Math.floor(options.issuedAt));
+    } else if (claims.iat === undefined) {
+        claims.iat = timestamp;
+    } else {
+        assertNumericClaim('iat', claims.iat);
+    }
+
+    if (options.expiresIn !== undefined) {
+        if (typeof options.expiresIn !== 'number' || !Number.isFinite(options.expiresIn) || options.expiresIn <= 0) {
+            throw new Error('expiresIn must be a positive number of seconds.');
+        }
+        assertClaimConsistency(claims, 'exp', timestamp + Math.floor(options.expiresIn));
+    } else if (claims.exp !== undefined) {
+        assertNumericClaim('exp', claims.exp);
+    }
+
+    if (options.notBefore !== undefined) {
+        if (typeof options.notBefore !== 'number' || !Number.isFinite(options.notBefore)) {
+            throw new Error('notBefore must be a number of seconds.');
+        }
+        assertClaimConsistency(claims, 'nbf', timestamp + Math.floor(options.notBefore));
+    } else if (claims.nbf !== undefined) {
+        assertNumericClaim('nbf', claims.nbf);
+    }
+
+    if (options.audience !== undefined) {
+        const audiences = normalizeAudience(options.audience);
+        assertClaimConsistency(claims, 'aud', audiences.length === 1 ? audiences[0] : audiences);
+    } else if (claims.aud !== undefined) {
+        if (Array.isArray(claims.aud)) {
+            claims.aud = normalizeAudience(claims.aud);
+        } else {
+            assertStringClaim('aud', claims.aud);
+        }
+    }
+
+    if (options.issuer !== undefined) {
+        assertStringClaim('iss', options.issuer);
+        assertClaimConsistency(claims, 'iss', options.issuer);
+    } else if (claims.iss !== undefined) {
+        assertStringClaim('iss', claims.iss);
+    }
+
+    if (options.subject !== undefined) {
+        assertStringClaim('sub', options.subject);
+        assertClaimConsistency(claims, 'sub', options.subject);
+    } else if (claims.sub !== undefined) {
+        assertStringClaim('sub', claims.sub);
+    }
+
+    const encodedHeader = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+    const encodedPayload = base64UrlEncode(Buffer.from(JSON.stringify(claims)));
+    const signingInput = `${encodedHeader}.${encodedPayload}`;
+    const signature = base64UrlEncode(createSignatureBuffer(algorithm, options.secret, signingInput));
+
+    return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+export function verifyJwt<T extends Record<string, unknown> = Record<string, unknown>>(
+    token: string,
+    options: VerifyJwtOptions
+): T {
+    if (typeof token !== 'string' || token.length === 0) {
+        throw new Error('Token must be a non-empty string.');
+    }
+    if (!options || typeof options.secret !== 'string' || options.secret.length === 0) {
+        throw new Error('A non-empty secret is required to verify a JWT.');
+    }
+
+    const parts = token.split('.');
+    if (parts.length !== 3 || parts.some(part => part.length === 0)) {
+        throw new Error('Invalid token structure.');
+    }
+
+    const [encodedHeader, encodedPayload, encodedSignature] = parts;
+    const headerBuffer = base64UrlDecode(encodedHeader, 'header');
+    let header: JwtHeader;
+    try {
+        const parsed = JSON.parse(headerBuffer.toString('utf8'));
+        if (!isPlainObject(parsed)) {
+            throw new Error('Header must be a JSON object.');
+        }
+        header = parsed as JwtHeader;
+    } catch (error) {
+        throw new Error('Invalid JWT header.');
+    }
+
+    if (header.alg === undefined || typeof header.alg !== 'string') {
+        throw new Error('Missing JWT algorithm.');
+    }
+    if (header.alg.toUpperCase() === 'NONE') {
+        throw new Error('Unsigned JWTs (alg "none") are not allowed.');
+    }
+
+    const algorithm = header.alg.toUpperCase() as JwtAlgorithm;
+    if (!HASH_ALGORITHMS[algorithm]) {
+        throw new Error(`Unsupported algorithm: ${header.alg}.`);
+    }
+
+    if (header.typ !== undefined && header.typ !== 'JWT') {
+        throw new Error('Invalid JWT type.');
+    }
+
+    if (options.algorithms && !options.algorithms.includes(algorithm)) {
+        throw new Error(`Algorithm ${algorithm} is not allowed.`);
+    }
+
+    const payloadBuffer = base64UrlDecode(encodedPayload, 'payload');
+    let payload: JwtPayload;
+    try {
+        const parsed = JSON.parse(payloadBuffer.toString('utf8'));
+        if (!isPlainObject(parsed)) {
+            throw new Error('Payload must be a JSON object.');
+        }
+        payload = parsed as JwtPayload;
+    } catch (error) {
+        throw new Error('Invalid JWT payload.');
+    }
+
+    const expectedSignature = createSignatureBuffer(algorithm, options.secret, `${encodedHeader}.${encodedPayload}`);
+    const providedSignature = base64UrlDecode(encodedSignature, 'signature');
+
+    if (providedSignature.length !== expectedSignature.length) {
+        throw new Error('Invalid JWT signature.');
+    }
+    if (!crypto.timingSafeEqual(providedSignature, expectedSignature)) {
+        throw new Error('Invalid JWT signature.');
+    }
+
+    validateTemporalClaims(payload, options);
+    validateAudienceClaim(payload, options);
+    validateIssuerClaim(payload, options);
+    validateSubjectClaim(payload, options);
+
+    return payload as T;
+}
+
+function validateTemporalClaims(payload: JwtPayload, options: VerifyJwtOptions): void {
+    const now = getTimestamp(options.clockTimestamp);
+    const tolerance = options.clockTolerance ?? 0;
+    if (!Number.isFinite(tolerance) || tolerance < 0) {
+        throw new Error('clockTolerance must be a non-negative number.');
+    }
+
+    if (payload.exp !== undefined) {
+        assertNumericClaim('exp', payload.exp);
+        if (now > payload.exp + tolerance) {
+            throw new Error('JWT expired.');
+        }
+    }
+
+    if (payload.nbf !== undefined) {
+        assertNumericClaim('nbf', payload.nbf);
+        if (now + tolerance < payload.nbf) {
+            throw new Error('JWT not active yet.');
+        }
+    }
+
+    if (payload.iat !== undefined) {
+        assertNumericClaim('iat', payload.iat);
+        if (payload.iat - tolerance > now) {
+            throw new Error('JWT used before issued.');
+        }
+    }
+
+    if (options.maxAge !== undefined) {
+        if (!Number.isFinite(options.maxAge) || options.maxAge <= 0) {
+            throw new Error('maxAge must be a positive number of seconds.');
+        }
+        if (payload.iat === undefined) {
+            throw new Error('Cannot apply maxAge without an "iat" claim.');
+        }
+        if (now - payload.iat - tolerance > options.maxAge) {
+            throw new Error('JWT exceeds maxAge.');
+        }
+    }
+}
+
+function validateAudienceClaim(payload: JwtPayload, options: VerifyJwtOptions): void {
+    if (payload.aud === undefined && options.audience === undefined) {
+        return;
+    }
+
+    let tokenAudience: string[];
+    if (payload.aud !== undefined) {
+        if (Array.isArray(payload.aud)) {
+            tokenAudience = normalizeAudience(payload.aud);
+        } else {
+            assertStringClaim('aud', payload.aud);
+            tokenAudience = [payload.aud];
+        }
+    } else {
+        throw new Error('JWT missing required audience claim.');
+    }
+
+    if (options.audience === undefined) {
+        return;
+    }
+
+    const expectedAudiences = normalizeAudience(options.audience);
+    const hasMatch = expectedAudiences.some(expected => tokenAudience.includes(expected));
+    if (!hasMatch) {
+        throw new Error('JWT audience mismatch.');
+    }
+}
+
+function validateIssuerClaim(payload: JwtPayload, options: VerifyJwtOptions): void {
+    if (payload.iss === undefined && options.issuer === undefined) {
+        return;
+    }
+
+    if (payload.iss === undefined) {
+        throw new Error('JWT missing required issuer claim.');
+    }
+    assertStringClaim('iss', payload.iss);
+
+    if (options.issuer === undefined) {
+        return;
+    }
+
+    if (Array.isArray(options.issuer)) {
+        const allowed = options.issuer.some(value => {
+            if (typeof value !== 'string' || value.length === 0) {
+                throw new Error('Issuer values must be non-empty strings.');
+            }
+            return value === payload.iss;
+        });
+        if (!allowed) {
+            throw new Error('JWT issuer mismatch.');
+        }
+    } else {
+        if (typeof options.issuer !== 'string' || options.issuer.length === 0) {
+            throw new Error('Issuer must be a non-empty string.');
+        }
+        if (options.issuer !== payload.iss) {
+            throw new Error('JWT issuer mismatch.');
+        }
+    }
+}
+
+function validateSubjectClaim(payload: JwtPayload, options: VerifyJwtOptions): void {
+    if (payload.sub === undefined && options.subject === undefined) {
+        return;
+    }
+
+    if (payload.sub === undefined) {
+        throw new Error('JWT missing required subject claim.');
+    }
+    assertStringClaim('sub', payload.sub);
+
+    if (options.subject === undefined) {
+        return;
+    }
+
+    if (typeof options.subject !== 'string' || options.subject.length === 0) {
+        throw new Error('Subject must be a non-empty string.');
+    }
+
+    if (payload.sub !== options.subject) {
+        throw new Error('JWT subject mismatch.');
+    }
+}


### PR DESCRIPTION
## Summary
- add a zero-dependency JWT module with HS256/HS512 signing, verification, and hardened claim validation
- expose JWT helpers through AdvancedTokenManager and provide runnable examples plus security notes
- expand documentation and Jest coverage to exercise valid and invalid JWT scenarios

## Testing
- `npm test`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_69049bbbe27c832590000f59ef75a47e